### PR TITLE
set value to characteristic after reading it

### DIFF
--- a/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga/src/main/java/org/eclipse/smarthome/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
+++ b/extensions/binding/org.eclipse.smarthome.binding.bluetooth.bluegiga/src/main/java/org/eclipse/smarthome/binding/bluetooth/bluegiga/BlueGigaBluetoothDevice.java
@@ -417,6 +417,8 @@ public class BlueGigaBluetoothDevice extends BluetoothDevice implements BlueGiga
             if (characteristic == null) {
                 logger.debug("BlueGiga didn't find characteristic for event {}", event);
             } else {
+                characteristic.setValue(valueEvent.getValue());
+
                 // If this is the characteristic we were reading, then send a read completion
                 if (procedureProgress == BlueGigaProcedure.CHARACTERISTIC_READ && procedureCharacteristic != null
                         && procedureCharacteristic.getHandle() == valueEvent.getAttHandle()) {


### PR DESCRIPTION
I made the changes in BlueGigaBluetoothDevice.java because after calling `device.readCharacteristic()` method in my handler and calling `myCharacteristic.getValue()`, I get an empty array and I also saw that none of the overloaded `BluetoothCharacteristic.setValue()` method implementations was used in the BlueGiga Bundle to set the value after reading it from the device. These changes seem to have worked for my device (a distance sensor).


I am suggesting the changes in the BeaconBluetoothHandler.java, because I noticed that when trying to initialize the device with BlueZ, the `thing.configuration()`  doesn't have **address** as a key, but `thing.getProperties()` does. My DiscoveryParticipant implementation creates the DiscoveryResult with the address included in the properties.

Signed-off-by: Lyubomir V. Papazov <lpapazow@gmail.com>