### PR TITLE
Paper UI: only rely on "enabled" flag when displaying status

### DIFF
--- a/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/dto/EnrichedRuleDTO.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/dto/EnrichedRuleDTO.java
@@ -23,7 +23,6 @@ import org.eclipse.smarthome.automation.dto.RuleDTO;
  */
 public class EnrichedRuleDTO extends RuleDTO {
 
-    public boolean enabled;
     public RuleStatusInfo status;
 
 }

--- a/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/dto/EnrichedRuleDTOMapper.java
+++ b/bundles/automation/org.eclipse.smarthome.automation.rest/src/main/java/org/eclipse/smarthome/automation/rest/internal/dto/EnrichedRuleDTOMapper.java
@@ -26,7 +26,6 @@ public class EnrichedRuleDTOMapper extends RuleDTOMapper {
     public static EnrichedRuleDTO map(final Rule rule, final RuleManager ruleEngine) {
         final EnrichedRuleDTO enrichedRuleDto = new EnrichedRuleDTO();
         fillProperties(rule, enrichedRuleDto);
-        enrichedRuleDto.enabled = rule.isEnabled();
         enrichedRuleDto.status = rule.getStatusInfo();
         return enrichedRuleDto;
     }

--- a/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-services.js
+++ b/extensions/ui/org.eclipse.smarthome.ui.paper/web-src/js/repositories/repositories-services.js
@@ -217,11 +217,6 @@ angular.module('PaperUI.services.repositories')//
             existing.status = {};
             existing.status.status = rule.status;
             existing.status.statusDetail = rule.statusDetail;
-            if (rule.status.toUpperCase() === "DISABLED") {
-                existing.enabled = false;
-            } else {
-                existing.enabled = true;
-            }
         });
     });
 


### PR DESCRIPTION
Also: send "enabled" flag in rule status events.

Signed-off-by: Henning Treu <henning.treu@telekom.de>